### PR TITLE
Attendees should take some time to eat before vacating their seat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = project
   .settings(
     name := "zio-intro-game",
     organization := "net.degoes",
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.12.10",
     initialCommands in Compile in console :=
       """|import zio._
          |import zio.console._

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.8

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.1")


### PR DESCRIPTION
Previously only seat 1 of the table was being taken since location + eating + vacating were part of the same STM transaction. This change splits it up into vacating a seat and eating (1 STM transaction) followed by a delay followed by another STM transaction where the user finishes eating and vacates their seat. 

**Updates included**
- Scala 2.12.10
- SBT 1.3.8
- SBT Scalafmt 2.3.1

Thanks for the great exercises 😋 