### PR TITLE
Calculate diagonal win in TicTacToe game when both marks present

### DIFF
--- a/src/main/scala/net/degoes/zio/Workshop.scala
+++ b/src/main/scala/net/degoes/zio/Workshop.scala
@@ -1053,9 +1053,8 @@ object TicTacToe extends App {
         colInc: Int
     ): Iterable[Option[Mark]] =
       for {
-        row <- (row0 to (row0 + rowInc * 2))
-        col <- (col0 to (col0 + colInc * 2))
-      } yield value(row)(col)
+        i <- 0 to 2
+      } yield value(row0 + rowInc * i)(col0 + colInc * i)
   }
   object Board {
     final val empty = new Board(Vector.fill(3)(Vector.fill(3)(None)))

--- a/src/test/scala/net/degoes/zio/WorkshopSpec.scala
+++ b/src/test/scala/net/degoes/zio/WorkshopSpec.scala
@@ -54,6 +54,9 @@ object WorkshopSpec
           },
           test("won diagonal second") {
             diagonalSecond(Mark.X) && diagonalSecond(Mark.O)
+          },
+          test("won diagonal special") {
+            diagonalSpecial
           }
         )
       )
@@ -179,6 +182,19 @@ object BoardHelpers {
         )
         .flatMap(_.won),
       isSome(equalTo(mark))
+    )
+  }
+
+  def diagonalSpecial = {
+    assert(
+      Board
+        .fromChars(
+          List('o', 'x', 'x'),
+          List('o', 'x', 'o'),
+          List('x', 'o', 'x')
+        )
+        .flatMap(_.won),
+      isSome(equalTo(Mark.X))
     )
   }
 }


### PR DESCRIPTION
Calculate diagonal win in TicTacToe game when both marks present with test case.
Currently in case of not only Mark.X / Mark.O diagonal win doesn't work as expected.